### PR TITLE
feature: Extend executeScriptCalls to support additional shared contexts and deduplicate scripts

### DIFF
--- a/src/targeted/bonuses/script-call-bonus.mjs
+++ b/src/targeted/bonuses/script-call-bonus.mjs
@@ -34,16 +34,22 @@ export class ScriptCallBonus extends BaseBonus {
         async function executeScriptCalls(category, extraParams = {}, shared = {}) {
             /** @type {ItemScriptCall[]} */
             const scripts = this.scriptCalls?.filter((o) => o.category === category) ?? [];
+            const addedKeys = new Set(scripts.map((s) => `${s.parent?.uuid ?? this.uuid}:${s.id}:${s.category}:${s.type}:${s.value}`));
 
             // BEGIN MY OVERRIDE
-            if (shared.action) {
+            const rbShared = /** @type {any} */ (shared);
+            const contexts = [rbShared.actionUse, shared.action, this].filter((c, i, arr) => c && arr.indexOf(c) === i);
+            if (contexts.length) {
                 handleBonusesFor(
                     shared.action,
                     (bonusType, sourceItem) => {
-                        const scriptCalls = bonusType.getScriptCalls(sourceItem, this);
-                        scriptCalls
-                            .filter((s) => s.category === category)
-                            .forEach((s) => {
+                        const scriptCalls = /** @type {typeof ScriptCallBonus} */ (bonusType).getScriptCalls(sourceItem, this);
+                        const matching = scriptCalls.filter((/** @type {ItemScriptCall} */ s) => s.category === category);
+                        matching
+                            .forEach((/** @type {ItemScriptCall} */ s) => {
+                                const key = `${sourceItem.uuid}:${s.id}:${s.category}:${s.type}:${s.value}`;
+                                if (addedKeys.has(key)) return;
+                                addedKeys.add(key);
                                 scripts.push(s);
                             });
                     },
@@ -184,3 +190,4 @@ export class ScriptCallBonus extends BaseBonus {
         });
     }
 }
+


### PR DESCRIPTION
Currently, the executeScriptCalls override in ScriptCallBonus only checks shared.action when collecting bonus script calls. This works well for the standard action flow, but other modules can pass script call contexts through shared.actionUse or on the item itself (e.g. modules that add custom script call categories that fire outside the typical ActionUse pipeline).

My new script hooks mod (https://github.com/Hamilcarbarcas/pf1-new-script-hooks) can pass its script call contexts through shared.actionUse or the item itself, which is not currently checked in your script calls bonus. Your mod already populates the selection of the script calls I added, but they do not execute without checking the new contexts. I added the functionality to check those contexts with this change.

This change makes two additions that makes it compatible with new script hooks:

1. Check multiple contexts
Builds a deduplicated list of contexts from shared.actionUse, shared.action, and the item (this), then passes all of them to handleBonusesFor. This allows Roll Bonuses script calls to fire regardless of which pathway triggers executeScriptCalls.

2. Deduplicate script calls
Adds a Set-based check keyed on uuid:id:category:type:value to prevent the same script call from being pushed into the execution list more than once. This can happen when the same bonus is reachable through multiple contexts.

Both changes are (best as I can tell) backward-compatible — the existing shared.action path continues to work exactly as before, and the deduplication is a no-op when there are no duplicates.