### PR TITLE
Fix/conditional input css syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tools/link-to-foundry.cmd
+packs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 tools/link-to-foundry.cmd
-packs/

--- a/src/handlebars-handlers/targeted/bonuses/conditional-modifiers-input.mjs
+++ b/src/handlebars-handlers/targeted/bonuses/conditional-modifiers-input.mjs
@@ -188,7 +188,7 @@ export function modifiersInput({
     }
 
     setTimeout(() => {
-        const conditionalInput = document.querySelector(`#${createId(item, key)}`);
+        const conditionalInput = document.getElementById(createId(item, key));
         // @ts-ignore
         const jq = $(conditionalInput);
         // jq.find('.conditional.flexrow')?.hide();


### PR DESCRIPTION
Opening an item with a conditional modifier roll bonus in the compendium will throw a syntax error in the console if the first digit of the document id is a number.

The element id is built from the Foundry document id (${item.id}-${key}). HTML allows an id attribute to start with a digit, but a CSS selector identifier cannot — so document.querySelector('#…') errors for any item whose id begins with a number.

Fix:
Use document.getElementById() (takes a raw id rather than CSS selector) instead of querySelector in conditional-modifiers-input.mjs.